### PR TITLE
Indentation and import solved issues.  Compatibility with Python 2 and 3 (CASA 5 and 6)

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -43,7 +43,7 @@ casalog.setlogfile(CASA_logfile)
 try:
     import ConfigParser
     config = ConfigParser.ConfigParser()
-except ImportError:
+except ModuleNotFoundError:
     import configparser
     config = configparser.ConfigParser()
 

--- a/capture.py
+++ b/capture.py
@@ -17,6 +17,11 @@
 
 import logging
 import os
+import sys
+import numpy as np
+current_dir = os.path.dirname(__file__)
+sys.path.append(current_dir)
+
 from datetime import datetime
 logfile_name = datetime.now().strftime('capture_%H_%M_%S_%d_%m_%Y.log')
 logging.basicConfig(filename=logfile_name,level=logging.DEBUG)
@@ -35,10 +40,18 @@ logging.info("##################################################################
 CASA_logfile = 'casa-'+logfile_name
 casalog.setlogfile(CASA_logfile)
 
-import ConfigParser
-config = ConfigParser.ConfigParser()
+try:
+    import ConfigParser
+    config = ConfigParser.ConfigParser()
+except ImportError:
+    import configparser
+    config = configparser.ConfigParser()
+
 config.read('config_capture.ini')
 
+# from ugfunctions import *
+# execfile('ugfunctions.py')
+exec(open(f"{current_dir}/ugfunctions.py").read())
 
 fromlta = config.getboolean('basic', 'fromlta')
 fromfits = config.getboolean('basic', 'fromfits')
@@ -85,19 +98,17 @@ uvrascal=config.get('default','uvrascal')
 target = config.getboolean('default','target')
 
 
-execfile('ugfunctions.py')
-
 testfitsfile = False
 
 if fromlta == True:
-	logging.info("You have chosen to convert lta to FITS.")
-	testltafile = os.path.isfile(ltafile)
-	if testltafile == True:
-		logging.info("The lta %s file exists.", ltafile)
-		testlistscan = os.path.isfile(gvbinpath[0])
-		testgvfits = os.path.isfile(gvbinpath[1])
-		if testlistscan and testgvfits == True:
-			os.system(gvbinpath[0]+' '+ltafile)
+        logging.info("You have chosen to convert lta to FITS.")
+        testltafile = os.path.isfile(ltafile)
+        if testltafile == True:
+                logging.info("The lta %s file exists.", ltafile)
+                testlistscan = os.path.isfile(gvbinpath[0])
+                testgvfits = os.path.isfile(gvbinpath[1])
+                if testlistscan and testgvfits == True:
+                        os.system(gvbinpath[0]+' '+ltafile)
                         if fits_file!= '' and fits_file != 'TEST.FITS':
                                 os.system("sed -i 's/TEST.FITS/'"+fits_file+"/ "+ltafile.split('.')[0]+'.log')
                         try:
@@ -110,14 +121,14 @@ if fromlta == True:
                                         testfitsfile = True
                                         fits_file = 'TEST.FITS'
                                 else:
-		                        os.system(gvbinpath[1]+' '+ltafile.split('.')[0]+'.log')
+                                        os.system(gvbinpath[1]+' '+ltafile.split('.')[0]+'.log')
                                         testfitsfile = True
-    		else:	
-			logging.info("Error: Check if listscan and gvfits are present and executable.")
-	else:
-		logging.info("The given lta file does not exist. Exiting the code.")
-		logging.info("If you are not starting from lta file please set fromlta to False and rerun.")
-		sys.exit()
+                else:   
+                        logging.info("Error: Check if listscan and gvfits are present and executable.")
+        else:
+                logging.info("The given lta file does not exist. Exiting the code.")
+                logging.info("If you are not starting from lta file please set fromlta to False and rerun.")
+                sys.exit()
 
 
 #testfitsfile = False 
@@ -135,7 +146,7 @@ if fromfits == True:
                                 logging.info("Please provide the name of the FITS file.")
                                 sys.exit()
 
-		
+                
 
 if testfitsfile == True:
         if msfilename != '':
@@ -148,19 +159,19 @@ if testfitsfile == True:
                         assert os.path.isdir(fits_file+'.MS')
                 except AssertionError:
                         msfilename = fits_file+'.MS'           
-	default(importgmrt)
-	importgmrt(fitsfile=fits_file, vis = msfilename)
-	if os.path.isfile(msfilename+'.list') == True:
-		os.system('rm '+msfilename+'.list')
-	vislistobs(msfilename)
+        default(importgmrt)
+        importgmrt(fitsfile=fits_file, vis = msfilename)
+        if os.path.isfile(msfilename+'.list') == True:
+                os.system('rm '+msfilename+'.list')
+        vislistobs(msfilename)
         logging.info("Please see the text file with the extension .list to find out more about your data.")
-	
+        
 
 testms = False
 
 if frommultisrcms == True:
         if msfilename != '':
-	        testms = os.path.isdir(msfilename)
+                testms = os.path.isdir(msfilename)
         else:
                 try:
                         assert os.path.isdir('TEST.FITS.MS')
@@ -169,86 +180,86 @@ if frommultisrcms == True:
                 except AssertionError:
                         logging.info("Tried to find the MS file with default name. File not found. Please provide the name of the msfile or create the MS by setting fromfits = True.")
                         sys.exit()
-	if testms == False:
-		logging.info("The MS file does not exist. Please provide msfilename. Exiting the code...")
+        if testms == False:
+                logging.info("The MS file does not exist. Please provide msfilename. Exiting the code...")
                 sys.exit()
 
 
 if testms == True:
         gainspw, mygoodchans, flagspw, mypol = getgainspw(msfilename)
-	logging.info("Channel range for calibration:")
+        logging.info("Channel range for calibration:")
         logging.info(gainspw)
-	logging.info("Assumed clean channel range:")
+        logging.info("Assumed clean channel range:")
         logging.info(mygoodchans)
-	logging.info("Channel range for flagging:")
+        logging.info("Channel range for flagging:")
         logging.info(flagspw)
-	logging.info("Polarizations in the file:")
+        logging.info("Polarizations in the file:")
         logging.info(mypol)
 # fix targets
-	myfields = getfields(msfilename)
-	stdcals = ['3C48','3C147','3C286','0542+498','1331+305','0137+331']
-	vlacals = np.loadtxt('./vla-cals.list',dtype='string')
-	myampcals =[]
-	mypcals=[]
-	mytargets=[]
-	for i in range(0,len(myfields)):
-		if myfields[i] in stdcals:
-			myampcals.append(myfields[i])
-		elif myfields[i] in vlacals:
-			mypcals.append(myfields[i])
-		else:
-			mytargets.append(myfields[i])
-	mybpcals = myampcals
-	logging.info('Amplitude caibrators are %s', str(myampcals))
-	logging.info('Phase calibrators are %s', str(mypcals))
-	logging.info('Target sources are %s', str(mytargets))
+        myfields = getfields(msfilename)
+        stdcals = ['3C48','3C147','3C286','0542+498','1331+305','0137+331']
+        vlacals = np.loadtxt(f'{current_dir}/vla-cals.list',dtype='str')
+        myampcals =[]
+        mypcals=[]
+        mytargets=[]
+        for i in range(0,len(myfields)):
+                if myfields[i] in stdcals:
+                        myampcals.append(myfields[i])
+                elif myfields[i] in vlacals:
+                        mypcals.append(myfields[i])
+                else:
+                        mytargets.append(myfields[i])
+        mybpcals = myampcals
+        logging.info('Amplitude caibrators are %s', str(myampcals))
+        logging.info('Phase calibrators are %s', str(mypcals))
+        logging.info('Target sources are %s', str(mytargets))
 # need a condition to see if the pcal is same as 
-	ampcalscans =[]
-	for i in range(0,len(myampcals)):
-		ampcalscans.extend(getscans(msfilename, myampcals[i]))
-	pcalscans=[]
-	for i in range(0,len(mypcals)):
-		pcalscans.extend(getscans(msfilename, mypcals[i]))
-	tgtscans=[]
-	for i in range(0,len(mytargets)):
-		tgtscans.extend(getscans(msfilename,mytargets[i]))
-#	print(ampcalscans)
-	logging.info("Amplitude calibrator scans are:")
+        ampcalscans =[]
+        for i in range(0,len(myampcals)):
+                ampcalscans.extend(getscans(msfilename, myampcals[i]))
+        pcalscans=[]
+        for i in range(0,len(mypcals)):
+                pcalscans.extend(getscans(msfilename, mypcals[i]))
+        tgtscans=[]
+        for i in range(0,len(mytargets)):
+                tgtscans.extend(getscans(msfilename,mytargets[i]))
+#       print(ampcalscans)
+        logging.info("Amplitude calibrator scans are:")
         logging.info(ampcalscans)
-#	print(pcalscans)
-	logging.info("Phase calibrator scans are:")
+#       print(pcalscans)
+        logging.info("Phase calibrator scans are:")
         logging.info(pcalscans)
-#	print(tgtscans)
-	logging.info("Target source scans are:")
+#       print(tgtscans)
+        logging.info("Target source scans are:")
         logging.info(tgtscans)
-	allscanlist= ampcalscans+pcalscans+tgtscans
+        allscanlist= ampcalscans+pcalscans+tgtscans
 ###################################
 # get a list of antennas
-	antsused = getantlist(msfilename,int(allscanlist[0]))
-	logging.info("Antennas in the file:")
+        antsused = getantlist(msfilename,int(allscanlist[0]))
+        logging.info("Antennas in the file:")
         logging.info(antsused)
 ###################################
 # find band ants
-	if flagbadants==True:
-		findbadants = True
-	if findbadants == True:
-		myantlist = antsused
-		mycmds = []
+        if flagbadants==True:
+                findbadants = True
+        if findbadants == True:
+                myantlist = antsused
+                mycmds = []
 #############
-		meancutoff = getbandcut(msfilename)
+                meancutoff = getbandcut(msfilename)
 #############
-		mycorr1='rr'
-		mycorr2='ll'
-		mygoodchans1=mygoodchans
-		mycalscans = ampcalscans+pcalscans
-#		print(mycalscans)
-		logging.info("Calibrator scan numbers:")
-		logging.info(mycalscans)
-		allbadants=[]
-		for j in range(0,len(mycalscans)):
-			myantmeans = []
-			badantlist = []
-			for i in range(0,len(myantlist)):
+                mycorr1='rr'
+                mycorr2='ll'
+                mygoodchans1=mygoodchans
+                mycalscans = ampcalscans+pcalscans
+#               print(mycalscans)
+                logging.info("Calibrator scan numbers:")
+                logging.info(mycalscans)
+                allbadants=[]
+                for j in range(0,len(mycalscans)):
+                        myantmeans = []
+                        badantlist = []
+                        for i in range(0,len(myantlist)):
                                 if mypol == 1:
                                         if poldata == 'RR':
                                                 oneantmean1 = myvisstatampraw(msfilename,mygoodchans,myantlist[i],mycorr1,str(mycalscans[j]))
@@ -259,51 +270,51 @@ if testms == True:
                                 else:
                                         oneantmean1 = myvisstatampraw(msfilename,mygoodchans,myantlist[i],mycorr1,str(mycalscans[j]))
                                         oneantmean2 = myvisstatampraw(msfilename,mygoodchans,myantlist[i],mycorr2,str(mycalscans[j]))
-				oneantmean = min(oneantmean1,oneantmean2)
-				myantmeans.append(oneantmean)
-				if oneantmean < meancutoff:
-					badantlist.append(myantlist[i])
-					allbadants.append(myantlist[i])
-			logging.info("The following antennas are bad for the given scan numbers.")
-			logging.info('%s, %s',str(badantlist), str(mycalscans[j]))
-			if badantlist!=[]:
-				myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]))
-				mycmds.append(myflgcmd)
-				logging.info(myflgcmd)
-				onelessscan = mycalscans[j] - 1
-				onemorescan = mycalscans[j] + 1
-				if onelessscan in tgtscans:
-					myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]-1))
-					mycmds.append(myflgcmd)
-					logging.info(myflgcmd)
-				if onemorescan in tgtscans:
-					myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]+1))
-					mycmds.append(myflgcmd)
-					logging.info(myflgcmd)
+                                oneantmean = min(oneantmean1,oneantmean2)
+                                myantmeans.append(oneantmean)
+                                if oneantmean < meancutoff:
+                                        badantlist.append(myantlist[i])
+                                        allbadants.append(myantlist[i])
+                        logging.info("The following antennas are bad for the given scan numbers.")
+                        logging.info('%s, %s',str(badantlist), str(mycalscans[j]))
+                        if badantlist!=[]:
+                                myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]))
+                                mycmds.append(myflgcmd)
+                                logging.info(myflgcmd)
+                                onelessscan = mycalscans[j] - 1
+                                onemorescan = mycalscans[j] + 1
+                                if onelessscan in tgtscans:
+                                        myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]-1))
+                                        mycmds.append(myflgcmd)
+                                        logging.info(myflgcmd)
+                                if onemorescan in tgtscans:
+                                        myflgcmd = "mode='manual' antenna='%s' scan='%s'" % (str('; '.join(badantlist)), str(mycalscans[j]+1))
+                                        mycmds.append(myflgcmd)
+                                        logging.info(myflgcmd)
 # execute the flagging commands accumulated in cmds
-		if flagbadants==True:
-			logging.info("Now flagging the bad antennas.")
-			default(flagdata)
-			flagdata(vis=msfilename,mode='list', inpfile=mycmds)	
+                if flagbadants==True:
+                        logging.info("Now flagging the bad antennas.")
+                        default(flagdata)
+                        flagdata(vis=msfilename,mode='list', inpfile=mycmds)    
 ######### Bad channel flagging for known persistent RFI.
-	if flagbadfreq==True:
-		findbadchans = True
-	if findbadchans ==True:
-		rfifreqall =[0.36E09,0.3796E09,0.486E09,0.49355E09,0.8808E09,0.885596E09,0.7646E09,0.769092E09] # always bad
-		myfreqs =  freq_info(msfilename)
-		mybadchans=[]
-		for j in range(0,len(rfifreqall)-1,2):
-			for i in range(0,len(myfreqs)):
-				if (myfreqs[i] > rfifreqall[j] and myfreqs[i] < rfifreqall[j+1]): #(myfreqs[i] > 0.486E09 and myfreqs[i] < 0.49355E09):
-					mybadchans.append('0:'+str(i))
-		mychanflag = str(', '.join(mybadchans))
-		if mybadchans!=[]:
-			myflgcmd = ["mode='manual' spw='%s'" % (mychanflag)]
-			if flagbadfreq==True:
-				default(flagdata)
-				flagdata(vis=msfilename,mode='list', inpfile=myflgcmd)
-		else:
-			logging.info("None of the well-known RFI-prone frequencies were found in the data.")
+        if flagbadfreq==True:
+                findbadchans = True
+        if findbadchans ==True:
+                rfifreqall =[0.36E09,0.3796E09,0.486E09,0.49355E09,0.8808E09,0.885596E09,0.7646E09,0.769092E09] # always bad
+                myfreqs =  freq_info(msfilename)
+                mybadchans=[]
+                for j in range(0,len(rfifreqall)-1,2):
+                        for i in range(0,len(myfreqs)):
+                                if (myfreqs[i] > rfifreqall[j] and myfreqs[i] < rfifreqall[j+1]): #(myfreqs[i] > 0.486E09 and myfreqs[i] < 0.49355E09):
+                                        mybadchans.append('0:'+str(i))
+                mychanflag = str(', '.join(mybadchans))
+                if mybadchans!=[]:
+                        myflgcmd = ["mode='manual' spw='%s'" % (mychanflag)]
+                        if flagbadfreq==True:
+                                default(flagdata)
+                                flagdata(vis=msfilename,mode='list', inpfile=myflgcmd)
+                else:
+                        logging.info("None of the well-known RFI-prone frequencies were found in the data.")
 ############ Initial flagging ################
 if flaginit == True:
         try:
@@ -311,136 +322,136 @@ if flaginit == True:
         except AssertionError:
                 logging.info("flaginit = True but ms file not found.")
                 sys.exit()
-	casalog.filter('INFO')
+        casalog.filter('INFO')
 #Step 1 : Flag the first channel.
-	default(flagdata)
-	flagdata(vis=msfilename, mode='manual', field='', spw='0:0', antenna='', correlation='', action='apply', savepars=True,
-		cmdreason='badchan', outfile='')
+        default(flagdata)
+        flagdata(vis=msfilename, mode='manual', field='', spw='0:0', antenna='', correlation='', action='apply', savepars=True,
+                cmdreason='badchan', outfile='')
 #Step 3: Do a quack step 
-	default(flagdata)
-	flagdata(vis=msfilename, mode='quack', field='', spw='0', antenna='', correlation='', timerange='',
-		quackinterval=setquackinterval, quackmode='beg', action='apply', savepars=True, cmdreason='quackbeg',
-	        outfile='')
-	default(flagdata)
-	flagdata(vis=msfilename, mode='quack', field='', spw='0', antenna='', correlation='', timerange='', quackinterval=setquackinterval,
-		quackmode='endb', action='apply', savepars=True, cmdreason='quackendb', outfile='')
+        default(flagdata)
+        flagdata(vis=msfilename, mode='quack', field='', spw='0', antenna='', correlation='', timerange='',
+                quackinterval=setquackinterval, quackmode='beg', action='apply', savepars=True, cmdreason='quackbeg',
+                outfile='')
+        default(flagdata)
+        flagdata(vis=msfilename, mode='quack', field='', spw='0', antenna='', correlation='', timerange='', quackinterval=setquackinterval,
+                quackmode='endb', action='apply', savepars=True, cmdreason='quackendb', outfile='')
 # Clip at high amp levels
-	if myampcals !=[]:
-		default(flagdata)
-		flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(myampcals)), clipminmax=clipfluxcal, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
-        		action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
-	if mypcals !=[]:
-		default(flagdata)
-		flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(mypcals)), clipminmax=clipphasecal, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
-        		action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        if myampcals !=[]:
+                default(flagdata)
+                flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(myampcals)), clipminmax=clipfluxcal, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
+                        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        if mypcals !=[]:
+                default(flagdata)
+                flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(mypcals)), clipminmax=clipphasecal, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
+                        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
 # After clip, now flag using 'tfcrop' option for flux and phase cal tight flagging
-		flagdata(vis=msfilename,mode="tfcrop", datacolumn="DATA", field=str(','.join(mypcals)), ntime="scan",
-		        timecutoff=5.0, freqcutoff=5.0, timefit="line",freqfit="line",flagdimension="freqtime", 
-		        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
-		        action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="tfcrop", datacolumn="DATA", field=str(','.join(mypcals)), ntime="scan",
+                        timecutoff=5.0, freqcutoff=5.0, timefit="line",freqfit="line",flagdimension="freqtime", 
+                        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
+                        action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # Now extend the flags (80% more means full flag, change if required)
-		flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(','.join(mypcals)),datacolumn="DATA",clipzeros=True,
-		         ntime="scan", extendflags=False, extendpols=True,growtime=80.0, growfreq=80.0,growaround=False,
-		         flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(','.join(mypcals)),datacolumn="DATA",clipzeros=True,
+                         ntime="scan", extendflags=False, extendpols=True,growtime=80.0, growfreq=80.0,growaround=False,
+                         flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
 ######### target flagging ### clip first
-	if target == True:
-		if mytargets !=[]:
-			flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(mytargets)), clipminmax=cliptarget, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
-		        	action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        if target == True:
+                if mytargets !=[]:
+                        flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(','.join(mytargets)), clipminmax=cliptarget, datacolumn="DATA",clipoutside=True, clipzeros=True, extendpols=False, 
+                                action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
 # flagging with tfcrop before calibration
-			default(flagdata)
-			flagdata(vis=msfilename,mode="tfcrop", datacolumn="DATA", field=str(','.join(mytargets)), ntime="scan",
-		        	timecutoff=6.0, freqcutoff=6.0, timefit="poly",freqfit="poly",flagdimension="freqtime", 
-		        	extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
-		        	action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                        default(flagdata)
+                        flagdata(vis=msfilename,mode="tfcrop", datacolumn="DATA", field=str(','.join(mytargets)), ntime="scan",
+                                timecutoff=6.0, freqcutoff=6.0, timefit="poly",freqfit="poly",flagdimension="freqtime", 
+                                extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
+                                action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # Now extend the flags (80% more means full flag, change if required)
-			flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(','.join(mytargets)),datacolumn="DATA",clipzeros=True,
-		        	 ntime="scan", extendflags=False, extendpols=True,growtime=80.0, growfreq=80.0,growaround=False,
-		        	 flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                        flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(','.join(mytargets)),datacolumn="DATA",clipzeros=True,
+                                 ntime="scan", extendflags=False, extendpols=True,growtime=80.0, growfreq=80.0,growaround=False,
+                                 flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # Now summary
-		flagdata(vis=msfilename,mode="summary",datacolumn="DATA", extendflags=True, 
-	        	 name=vis+'summary.split', action="apply", flagbackup=True,overwrite=True, writeflags=True)	
+                flagdata(vis=msfilename,mode="summary",datacolumn="DATA", extendflags=True, 
+                         name=vis+'summary.split', action="apply", flagbackup=True,overwrite=True, writeflags=True)     
         logging.info("A flagging summary is provided for the MS file.")
         flagsummary(msfilename)
 #####################################################################
 # Calibration begins.
 if doinitcal == True:
-	assert os.path.isdir(msfilename)
+        assert os.path.isdir(msfilename)
         try:
                 assert os.path.isdir(msfilename), "doinitcal = True but ms file not found."
         except AssertionError:
                 logging.info("doinitcal = True but ms file not found.")
                 sys.exit()
-	mycalsuffix = ''
-	casalog.filter('INFO')
-	clearcal(vis=msfilename)
-	for i in range(0,len(myampcals)):
-		default(setjy)
-		setjy(vis=msfilename, spw=flagspw, field=myampcals[i])
+        mycalsuffix = ''
+        casalog.filter('INFO')
+        clearcal(vis=msfilename)
+        for i in range(0,len(myampcals)):
+                default(setjy)
+                setjy(vis=msfilename, spw=flagspw, field=myampcals[i])
 # Delay calibration  using the first flux calibrator in the list - should depend on which is less flagged
-	if os.path.isdir(str(msfilename)+'.K1'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.K1'+mycalsuffix)
-	gaincal(vis=msfilename, caltable=str(msfilename)+'.K1'+mycalsuffix, spw =flagspw, field=myampcals[0], 
-		solint='60s', refant=ref_ant,	solnorm= True, gaintype='K', gaintable=[], parang=True)
-	kcorrfield =myampcals[0]
+        if os.path.isdir(str(msfilename)+'.K1'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.K1'+mycalsuffix)
+        gaincal(vis=msfilename, caltable=str(msfilename)+'.K1'+mycalsuffix, spw =flagspw, field=myampcals[0], 
+                solint='60s', refant=ref_ant,   solnorm= True, gaintype='K', gaintable=[], parang=True)
+        kcorrfield =myampcals[0]
 # an initial bandpass
-	if os.path.isdir(str(msfilename)+'.AP.G0'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.AP.G0'+mycalsuffix)
-	default(gaincal)
-	gaincal(vis=msfilename, caltable=str(msfilename)+'.AP.G0'+mycalsuffix, append=True, field=str(','.join(mybpcals)), 
-		spw =flagspw, solint = 'int', refant = ref_ant, minsnr = 2.0, solmode = 'L1R', gaintype = 'G', calmode = 'ap', gaintable = [str(msfilename)+'.K1'+mycalsuffix],
-		interp = ['nearest,nearestflag', 'nearest,nearestflag' ], parang = True)
-	if os.path.isdir(str(msfilename)+'.B1'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.B1'+mycalsuffix)
-	default(bandpass)
-	bandpass(vis=msfilename, caltable=str(msfilename)+'.B1'+mycalsuffix, spw =flagspw, field=str(','.join(mybpcals)), solint='inf', refant=ref_ant, solnorm = True,
-		minsnr=2.0, fillgaps=8, parang = True, gaintable=[str(msfilename)+'.K1'+mycalsuffix,str(msfilename)+'.AP.G0'+mycalsuffix], interp=['nearest,nearestflag','nearest,nearestflag'])
+        if os.path.isdir(str(msfilename)+'.AP.G0'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.AP.G0'+mycalsuffix)
+        default(gaincal)
+        gaincal(vis=msfilename, caltable=str(msfilename)+'.AP.G0'+mycalsuffix, append=True, field=str(','.join(mybpcals)), 
+                spw =flagspw, solint = 'int', refant = ref_ant, minsnr = 2.0, solmode = 'L1R', gaintype = 'G', calmode = 'ap', gaintable = [str(msfilename)+'.K1'+mycalsuffix],
+                interp = ['nearest,nearestflag', 'nearest,nearestflag' ], parang = True)
+        if os.path.isdir(str(msfilename)+'.B1'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.B1'+mycalsuffix)
+        default(bandpass)
+        bandpass(vis=msfilename, caltable=str(msfilename)+'.B1'+mycalsuffix, spw =flagspw, field=str(','.join(mybpcals)), solint='inf', refant=ref_ant, solnorm = True,
+                minsnr=2.0, fillgaps=8, parang = True, gaintable=[str(msfilename)+'.K1'+mycalsuffix,str(msfilename)+'.AP.G0'+mycalsuffix], interp=['nearest,nearestflag','nearest,nearestflag'])
 # do a gaincal on all calibrators
-	mycals=myampcals+mypcals
-	i=0
-	if os.path.isdir(str(msfilename)+'.AP.G'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.AP.G'+mycalsuffix)
-	for i in range(0,len(mycals)):
-		mygaincal_ap2(msfilename,mycals[i],ref_ant,gainspw,uvracal,mycalsuffix)
+        mycals=myampcals+mypcals
+        i=0
+        if os.path.isdir(str(msfilename)+'.AP.G'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.AP.G'+mycalsuffix)
+        for i in range(0,len(mycals)):
+                mygaincal_ap2(msfilename,mycals[i],ref_ant,gainspw,uvracal,mycalsuffix)
 # Get flux scale
-	if os.path.isdir(str(msfilename)+'.fluxscale'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.fluxscale'+mycalsuffix)
+        if os.path.isdir(str(msfilename)+'.fluxscale'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.fluxscale'+mycalsuffix)
 ######################################
-	if mypcals !=[]:
-		if '3C286' in myampcals:
-			myfluxscale= getfluxcal2(msfilename,'3C286',str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = '3C286'
-		elif '3C147' in myampcals:
-			myfluxscale= getfluxcal2(msfilename,'3C147',str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = '3C147'
-		else:
-			myfluxscale= getfluxcal2(msfilename,myampcals[0],str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = myampcals[0]
-		logging.info(myfluxscale)
-		mygaintables =[str(msfilename)+'.fluxscale'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
-	else:
-		mygaintables =[str(msfilename)+'.AP.G'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
+        if mypcals !=[]:
+                if '3C286' in myampcals:
+                        myfluxscale= getfluxcal2(msfilename,'3C286',str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = '3C286'
+                elif '3C147' in myampcals:
+                        myfluxscale= getfluxcal2(msfilename,'3C147',str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = '3C147'
+                else:
+                        myfluxscale= getfluxcal2(msfilename,myampcals[0],str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = myampcals[0]
+                logging.info(myfluxscale)
+                mygaintables =[str(msfilename)+'.fluxscale'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
+        else:
+                mygaintables =[str(msfilename)+'.AP.G'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
 ##############################
-	for i in range(0,len(myampcals)):
-		default(applycal)
-		applycal(vis=msfilename, field=myampcals[i], spw = flagspw, gaintable=mygaintables, gainfield=[myampcals[i],'',''], 
-        		 interp=['nearest','',''], calwt=[False], parang=False)
+        for i in range(0,len(myampcals)):
+                default(applycal)
+                applycal(vis=msfilename, field=myampcals[i], spw = flagspw, gaintable=mygaintables, gainfield=[myampcals[i],'',''], 
+                         interp=['nearest','',''], calwt=[False], parang=False)
 #For phase calibrator:
-	if mypcals !=[]:
-		default(applycal)
-		applycal(vis=msfilename, field=str(', '.join(mypcals)), spw = flagspw, gaintable=mygaintables, gainfield=str(', '.join(mypcals)), 
-		         interp=['nearest','','nearest'], calwt=[False], parang=False)
+        if mypcals !=[]:
+                default(applycal)
+                applycal(vis=msfilename, field=str(', '.join(mypcals)), spw = flagspw, gaintable=mygaintables, gainfield=str(', '.join(mypcals)), 
+                         interp=['nearest','','nearest'], calwt=[False], parang=False)
 #For the target:
-	if target ==True:
-		if mypcals !=[]:
-			default(applycal)
-			applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
-		        	 gainfield=[str(', '.join(mypcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)
-		else:
-			default(applycal)
-			applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
-		        	 gainfield=[str(', '.join(myampcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)	
-	logging.info("Finished initial calibration.")
+        if target ==True:
+                if mypcals !=[]:
+                        default(applycal)
+                        applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
+                                 gainfield=[str(', '.join(mypcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)
+                else:
+                        default(applycal)
+                        applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
+                                 gainfield=[str(', '.join(myampcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)       
+        logging.info("Finished initial calibration.")
         logging.info("A flagging summary is provided for the MS file.")
         flagsummary(msfilename)
 #############################################################################3
@@ -451,59 +462,59 @@ if doflag == True:
         except AssertionError:
                 logging.info("doflag = True but ms file not found.")
                 sys.exit()
-	logging.info("You have chosen to flag after the initial calibration.")
-	default(flagdata)
-	if myampcals !=[]:
-		flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(myampcals)), clipminmax=clipfluxcal,
-        		datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
-        		action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
-	if mypcals !=[]:
-		flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(mypcals)), clipminmax=clipphasecal,
-        		datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
-        		action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        logging.info("You have chosen to flag after the initial calibration.")
+        default(flagdata)
+        if myampcals !=[]:
+                flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(myampcals)), clipminmax=clipfluxcal,
+                        datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
+                        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        if mypcals !=[]:
+                flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(mypcals)), clipminmax=clipphasecal,
+                        datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
+                        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
 # After clip, now flag using 'tfcrop' option for flux and phase cal tight flagging
-		flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mypcals)), ntime="scan",
-        		timecutoff=6.0, freqcutoff=5.0, timefit="line",freqfit="line",flagdimension="freqtime", 
-        		extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
-        		action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mypcals)), ntime="scan",
+                        timecutoff=6.0, freqcutoff=5.0, timefit="line",freqfit="line",flagdimension="freqtime", 
+                        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
+                        action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # now flag using 'rflag' option  for flux and phase cal tight flagging
-		flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mypcals)), timecutoff=5.0, 
-		        freqcutoff=5.0,timefit="poly",freqfit="line",flagdimension="freqtime", extendflags=False,
-		        timedevscale=4.0,freqdevscale=4.0,spectralmax=500.0,extendpols=False, growaround=False,
-		        flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mypcals)), timecutoff=5.0, 
+                        freqcutoff=5.0,timefit="poly",freqfit="line",flagdimension="freqtime", extendflags=False,
+                        timedevscale=4.0,freqdevscale=4.0,spectralmax=500.0,extendpols=False, growaround=False,
+                        flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
 # Now extend the flags (70% more means full flag, change if required)
-		flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(', '.join(mypcals)),datacolumn="corrected",clipzeros=True,
-		         ntime="scan", extendflags=False, extendpols=False,growtime=90.0, growfreq=90.0,growaround=False,
-		         flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="extend",spw=flagspw,field=str(', '.join(mypcals)),datacolumn="corrected",clipzeros=True,
+                         ntime="scan", extendflags=False, extendpols=False,growtime=90.0, growfreq=90.0,growaround=False,
+                         flagneartime=False, flagnearfreq=False, action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # Now flag for target - moderate flagging, more flagging in self-cal cycles
-	if mytargets !=[]:
-		flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(mytargets)), clipminmax=cliptarget,
-		        datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
-		        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
+        if mytargets !=[]:
+                flagdata(vis=msfilename,mode="clip", spw=flagspw,field=str(', '.join(mytargets)), clipminmax=cliptarget,
+                        datacolumn="corrected",clipoutside=True, clipzeros=True, extendpols=False, 
+                        action="apply",flagbackup=True, savepars=False, overwrite=True, writeflags=True)
 # C-C baselines are selected
-		a, b = getbllists(msfilename)
-		flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mytargets)), antenna=a[0],
-			ntime="scan", timecutoff=8.0, freqcutoff=8.0, timefit="poly",freqfit="line",flagdimension="freqtime", 
-		        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
-		        action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                a, b = getbllists(msfilename)
+                flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mytargets)), antenna=a[0],
+                        ntime="scan", timecutoff=8.0, freqcutoff=8.0, timefit="poly",freqfit="line",flagdimension="freqtime", 
+                        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
+                        action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # C- arm antennas and arm-arm baselines are selected.
-		flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mytargets)), antenna=b[0],
-			ntime="scan", timecutoff=6.0, freqcutoff=5.0, timefit="poly",freqfit="line",flagdimension="freqtime", 
-        		extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
-        		action="apply", flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="tfcrop", datacolumn="corrected", field=str(', '.join(mytargets)), antenna=b[0],
+                        ntime="scan", timecutoff=6.0, freqcutoff=5.0, timefit="poly",freqfit="line",flagdimension="freqtime", 
+                        extendflags=False, timedevscale=5.0,freqdevscale=5.0, extendpols=False,growaround=False,
+                        action="apply", flagbackup=True,overwrite=True, writeflags=True)
 # now flag using 'rflag' option
 # C-C baselines are selected
-		flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mytargets)), timecutoff=5.0, antenna=a[0],
-        		freqcutoff=8.0,timefit="poly",freqfit="poly",flagdimension="freqtime", extendflags=False,
-        		timedevscale=8.0,freqdevscale=5.0,spectralmax=500.0,extendpols=False, growaround=False,
-        		flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mytargets)), timecutoff=5.0, antenna=a[0],
+                        freqcutoff=8.0,timefit="poly",freqfit="poly",flagdimension="freqtime", extendflags=False,
+                        timedevscale=8.0,freqdevscale=5.0,spectralmax=500.0,extendpols=False, growaround=False,
+                        flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
 # C- arm antennas and arm-arm baselines are selected.
-		flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mytargets)), timecutoff=5.0, antenna=b[0],
-        		freqcutoff=5.0,timefit="poly",freqfit="poly",flagdimension="freqtime", extendflags=False,
-        		timedevscale=5.0,freqdevscale=5.0,spectralmax=500.0,extendpols=False, growaround=False,
-        		flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
+                flagdata(vis=msfilename,mode="rflag",datacolumn="corrected",field=str(', '.join(mytargets)), timecutoff=5.0, antenna=b[0],
+                        freqcutoff=5.0,timefit="poly",freqfit="poly",flagdimension="freqtime", extendflags=False,
+                        timedevscale=5.0,freqdevscale=5.0,spectralmax=500.0,extendpols=False, growaround=False,
+                        flagneartime=False,flagnearfreq=False,action="apply",flagbackup=True,overwrite=True, writeflags=True)
 # Now summary
-	flagdata(vis=msfilename,mode="summary",datacolumn="corrected", extendflags=True, 
+        flagdata(vis=msfilename,mode="summary",datacolumn="corrected", extendflags=True, 
          name=vis+'summary.split', action="apply", flagbackup=True,overwrite=True, writeflags=True)
         logging.info("A flagging summary is provided for the MS file.")
         flagsummary(msfilename)
@@ -516,115 +527,115 @@ if redocal == True:
         except AssertionError:
                 logging.info("redocal = True but ms file not found.")
                 sys.exit()
-	logging.info("You have chosen to redo the calibration on your data.")
-	mycalsuffix = 'recal'
-	casalog.filter('INFO')
-	clearcal(vis=msfilename)
-	for i in range(0,len(myampcals)):
-		default(setjy)
-		setjy(vis=msfilename, spw=flagspw, field=myampcals[i])
-		logging.info("Done setjy on %s"%(myampcals[i]))
+        logging.info("You have chosen to redo the calibration on your data.")
+        mycalsuffix = 'recal'
+        casalog.filter('INFO')
+        clearcal(vis=msfilename)
+        for i in range(0,len(myampcals)):
+                default(setjy)
+                setjy(vis=msfilename, spw=flagspw, field=myampcals[i])
+                logging.info("Done setjy on %s"%(myampcals[i]))
 # Delay calibration  using the first flux calibrator in the list - should depend on which is less flagged
-	if os.path.isdir(str(msfilename)+'.K1'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.K1'+mycalsuffix)
-	gaincal(vis=msfilename, caltable=str(msfilename)+'.K1'+mycalsuffix, spw =flagspw, field=myampcals[0], 
-		solint='60s', refant=ref_ant,	solnorm= True, gaintype='K', gaintable=[], parang=True)
-	kcorrfield =myampcals[0]
-#	print 'wrote table',str(msfilename)+'.K1'+mycalsuffix
+        if os.path.isdir(str(msfilename)+'.K1'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.K1'+mycalsuffix)
+        gaincal(vis=msfilename, caltable=str(msfilename)+'.K1'+mycalsuffix, spw =flagspw, field=myampcals[0], 
+                solint='60s', refant=ref_ant,   solnorm= True, gaintype='K', gaintable=[], parang=True)
+        kcorrfield =myampcals[0]
+#       print 'wrote table',str(msfilename)+'.K1'+mycalsuffix
 # an initial bandpass
-	if os.path.isdir(str(msfilename)+'.AP.G0'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.AP.G0'+mycalsuffix)
-	default(gaincal)
-	gaincal(vis=msfilename, caltable=str(msfilename)+'.AP.G0'+mycalsuffix, append=True, field=str(','.join(mybpcals)), 
-		spw =flagspw, solint = 'int', refant = ref_ant, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap', gaintable = [str(msfilename)+'.K1'],
-		interp = ['nearest,nearestflag', 'nearest,nearestflag' ], parang = True)
-	if os.path.isdir(str(msfilename)+'.B1'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.B1'+mycalsuffix)
-	default(bandpass)
-	bandpass(vis=msfilename, caltable=str(msfilename)+'.B1'+mycalsuffix, spw =flagspw, field=str(','.join(mybpcals)), solint='inf', refant=ref_ant, solnorm = True,
-		minsnr=2.0, fillgaps=8, parang = True, gaintable=[str(msfilename)+'.K1'+mycalsuffix,str(msfilename)+'.AP.G0'+mycalsuffix], interp=['nearest,nearestflag','nearest,nearestflag'])
+        if os.path.isdir(str(msfilename)+'.AP.G0'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.AP.G0'+mycalsuffix)
+        default(gaincal)
+        gaincal(vis=msfilename, caltable=str(msfilename)+'.AP.G0'+mycalsuffix, append=True, field=str(','.join(mybpcals)), 
+                spw =flagspw, solint = 'int', refant = ref_ant, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap', gaintable = [str(msfilename)+'.K1'],
+                interp = ['nearest,nearestflag', 'nearest,nearestflag' ], parang = True)
+        if os.path.isdir(str(msfilename)+'.B1'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.B1'+mycalsuffix)
+        default(bandpass)
+        bandpass(vis=msfilename, caltable=str(msfilename)+'.B1'+mycalsuffix, spw =flagspw, field=str(','.join(mybpcals)), solint='inf', refant=ref_ant, solnorm = True,
+                minsnr=2.0, fillgaps=8, parang = True, gaintable=[str(msfilename)+'.K1'+mycalsuffix,str(msfilename)+'.AP.G0'+mycalsuffix], interp=['nearest,nearestflag','nearest,nearestflag'])
 # do a gaingal on all calibrators
-	mycals=myampcals+mypcals
-	i=0
-	if os.path.isdir(str(msfilename)+'.AP.G'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.AP.G'+mycalsuffix)
-	for i in range(0,len(mycals)):
-		mygaincal_ap2(msfilename,mycals[i],ref_ant,gainspw,uvracal,mycalsuffix)
+        mycals=myampcals+mypcals
+        i=0
+        if os.path.isdir(str(msfilename)+'.AP.G'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.AP.G'+mycalsuffix)
+        for i in range(0,len(mycals)):
+                mygaincal_ap2(msfilename,mycals[i],ref_ant,gainspw,uvracal,mycalsuffix)
 # Get flux scale
-	if os.path.isdir(str(msfilename)+'.fluxscale'+mycalsuffix) == True:
-		os.system('rm -rf '+str(msfilename)+'.fluxscale'+mycalsuffix)
+        if os.path.isdir(str(msfilename)+'.fluxscale'+mycalsuffix) == True:
+                os.system('rm -rf '+str(msfilename)+'.fluxscale'+mycalsuffix)
 ########################################
-	if mypcals !=[]:
-		if '3C286' in myampcals:
-			myfluxscale= getfluxcal2(msfilename,'3C286',str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = '3C286'
-		elif '3C147' in myampcals:
-			myfluxscale= getfluxcal2(msfilename,'3C147',str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = '3C147'
-		else:
-			myfluxscale= getfluxcal2(msfilename,myampcals[0],str(', '.join(mypcals)),mycalsuffix)
-			myfluxscaleref = myampcals[0]
-		logging.info(myfluxscale)
-		mygaintables =[str(msfilename)+'.fluxscale'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
-	else:
-		mygaintables =[str(msfilename)+'.AP.G'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
+        if mypcals !=[]:
+                if '3C286' in myampcals:
+                        myfluxscale= getfluxcal2(msfilename,'3C286',str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = '3C286'
+                elif '3C147' in myampcals:
+                        myfluxscale= getfluxcal2(msfilename,'3C147',str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = '3C147'
+                else:
+                        myfluxscale= getfluxcal2(msfilename,myampcals[0],str(', '.join(mypcals)),mycalsuffix)
+                        myfluxscaleref = myampcals[0]
+                logging.info(myfluxscale)
+                mygaintables =[str(msfilename)+'.fluxscale'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
+        else:
+                mygaintables =[str(msfilename)+'.AP.G'+mycalsuffix,str(msfilename)+'.K1'+mycalsuffix, str(msfilename)+'.B1'+mycalsuffix]
 ###############################################################
-	for i in range(0,len(myampcals)):
-		default(applycal)
-		applycal(vis=msfilename, field=myampcals[i], spw = flagspw, gaintable=mygaintables, gainfield=[myampcals[i],'',''], 
-        		 interp=['nearest','',''], calwt=[False], parang=False)
+        for i in range(0,len(myampcals)):
+                default(applycal)
+                applycal(vis=msfilename, field=myampcals[i], spw = flagspw, gaintable=mygaintables, gainfield=[myampcals[i],'',''], 
+                         interp=['nearest','',''], calwt=[False], parang=False)
 #For phase calibrator:
-	if mypcals !=[]:
-		default(applycal)
-		applycal(vis=msfilename, field=str(', '.join(mypcals)), spw = flagspw, gaintable=mygaintables, gainfield=str(', '.join(mypcals)), 
-		         interp=['nearest','','nearest'], calwt=[False], parang=False)
+        if mypcals !=[]:
+                default(applycal)
+                applycal(vis=msfilename, field=str(', '.join(mypcals)), spw = flagspw, gaintable=mygaintables, gainfield=str(', '.join(mypcals)), 
+                         interp=['nearest','','nearest'], calwt=[False], parang=False)
 #For the target:
-	if target ==True:
-		if mypcals !=[]:
-			default(applycal)
-			applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
-		        	 gainfield=[str(', '.join(mypcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)
-		else:
-			default(applycal)
-			applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
-		        	 gainfield=[str(', '.join(myampcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)			
-	logging.info("Finished re-calibration.")
+        if target ==True:
+                if mypcals !=[]:
+                        default(applycal)
+                        applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
+                                 gainfield=[str(', '.join(mypcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)
+                else:
+                        default(applycal)
+                        applycal(vis=msfilename, field=str(', '.join(mytargets)), spw = flagspw, gaintable=mygaintables,
+                                 gainfield=[str(', '.join(myampcals)),'',''],interp=['linear','','nearest'], calwt=[False], parang=False)                       
+        logging.info("Finished re-calibration.")
         logging.info("A flagging summary is provided for the MS file.")
         flagsummary(msfilename)
 #############################################################
 # SPLIT step
 #############################################################
 if dosplit == True:
-#	assert os.path.isdir(msfilename), "dosplit = True but ms file not found."
+#       assert os.path.isdir(msfilename), "dosplit = True but ms file not found."
         try:
                 assert os.path.isdir(msfilename), "dosplit = True but ms file not found."
         except AssertionError:
                 logging.info("dosplit = True but ms file not found.")
                 sys.exit()
-	logging.info("The data on targets will be split into separate files.")
-	casalog.filter('INFO')
+        logging.info("The data on targets will be split into separate files.")
+        casalog.filter('INFO')
 # fix targets
-	myfields = getfields(msfilename)
-	stdcals = ['3C48','3C147','3C286','0542+498','1331+305','0137+331']
-	vlacals = np.loadtxt('./vla-cals.list',dtype='string')
-	myampcals =[]
-	mypcals=[]
-	mytargets=[]
-	for i in range(0,len(myfields)):
-		if myfields[i] in stdcals:
-			myampcals.append(myfields[i])
-		elif myfields[i] in vlacals:
-			mypcals.append(myfields[i])
-		else:
-			mytargets.append(myfields[i])
+        myfields = getfields(msfilename)
+        stdcals = ['3C48','3C147','3C286','0542+498','1331+305','0137+331']
+        vlacals = np.loadtxt(f'{current_dir}/vla-cals.list',dtype='str')
+        myampcals =[]
+        mypcals=[]
+        mytargets=[]
+        for i in range(0,len(myfields)):
+                if myfields[i] in stdcals:
+                        myampcals.append(myfields[i])
+                elif myfields[i] in vlacals:
+                        mypcals.append(myfields[i])
+                else:
+                        mytargets.append(myfields[i])
         gainspw1,goodchans,flg_chans,pols = getgainspw(msfilename)
-	for i in range(0,len(mytargets)):
-		if os.path.isdir(mytargets[i]+'split.ms') == True:
+        for i in range(0,len(mytargets)):
+                if os.path.isdir(mytargets[i]+'split.ms') == True:
                         logging.info("The existing split file will be deleted.")
-			os.system('rm -rf '+mytargets[i]+'split.ms')
+                        os.system('rm -rf '+mytargets[i]+'split.ms')
                 logging.info("Splitting target source data.")
                 logging.info(gainspw1)
-		splitfilename = mysplitinit(msfilename,mytargets[i],gainspw1,1)
+                splitfilename = mysplitinit(msfilename,mytargets[i],gainspw1,1)
 #############################################################
 # Flagging on split file
 #############################################################
@@ -636,16 +647,16 @@ if flagsplitfile == True:
                 logging.info("flagsplitfile = True but the split file not found.")
                 sys.exit()
         logging.info("Now proceeding to flag on the split file.")
-	myantselect =''
-	mytfcrop(splitfilename,'',myantselect,8.0,8.0,'DATA','')
-	a, b = getbllists(splitfilename)
-	tdev = 6.0
-	fdev = 6.0
-	myrflag(splitfilename,'',a[0],tdev,fdev,'DATA','')
-	tdev = 5.0
-	fdev = 5.0
-	myrflag(splitfilename,'',b[0],tdev,fdev,'DATA','')
-	logging.info("A flagging summary is provided for the MS file.")
+        myantselect =''
+        mytfcrop(splitfilename,'',myantselect,8.0,8.0,'DATA','')
+        a, b = getbllists(splitfilename)
+        tdev = 6.0
+        fdev = 6.0
+        myrflag(splitfilename,'',a[0],tdev,fdev,'DATA','')
+        tdev = 5.0
+        fdev = 5.0
+        myrflag(splitfilename,'',b[0],tdev,fdev,'DATA','')
+        logging.info("A flagging summary is provided for the MS file.")
         flagsummary(splitfilename)
 #############################################################
 # SPLIT AVERAGE
@@ -656,12 +667,12 @@ if dosplitavg == True:
         except AssertionError:
                 logging.info("dosplitavg = True but the split file not found.")
                 sys.exit()
-	logging.info("Your data will be averaged in frequency.")
+        logging.info("Your data will be averaged in frequency.")
         if os.path.isdir('avg-'+splitfilename) == True:
                 os.system('rm -rf avg-'+splitfilename)
                 if os.path.isdir('avg-'+splitfilename+'.flagversions') == True:
                        os.system('rm -rf avg-'+splitfilename+'.flagversions')
-	splitavgfilename = mysplitavg(splitfilename,'','',chanavg)
+        splitavgfilename = mysplitavg(splitfilename,'','',chanavg)
 
 
 if doflagavg == True:
@@ -670,10 +681,10 @@ if doflagavg == True:
         except AssertionError:
                 logging.info("doflagavg = True but the splitavg file not found.")
                 sys.exit()
-	logging.info("Flagging on freqeuncy averaged data.")
-	a, b = getbllists(splitavgfilename)
-	myrflagavg(splitavgfilename,'',b[0],6.0,6.0,'DATA','')
-	myrflagavg(splitavgfilename,'',a[0],6.0,6.0,'DATA','')
+        logging.info("Flagging on freqeuncy averaged data.")
+        a, b = getbllists(splitavgfilename)
+        myrflagavg(splitavgfilename,'',b[0],6.0,6.0,'DATA','')
+        myrflagavg(splitavgfilename,'',a[0],6.0,6.0,'DATA','')
         logging.info("A flagging summary is provided for the MS file.")
         flagsummary(splitavgfilename)
 
@@ -685,9 +696,9 @@ if makedirty == True:
         except AssertionError:
                 logging.info("makedirty = True but the splitavg file not found.")
                 sys.exit()
-	myfile2 = splitavgfilename
-	logging.info("A flagging summary is provided for the MS file.")
-	flagsummary(splitavgfilename)
+        myfile2 = splitavgfilename
+        logging.info("A flagging summary is provided for the MS file.")
+        flagsummary(splitavgfilename)
         mytclean(myfile2,0,mJythreshold,0,imcellsize,imsize_pix,use_nterms,nwprojpl)
 
 if doselfcal == True:
@@ -696,12 +707,12 @@ if doselfcal == True:
         except AssertionError:
                 logging.info("doselfcal = True but the splitavg file not found.")
                 sys.exit()
-	casalog.filter('INFO')
-	logging.info("A flagging summary is provided for the MS file.")
-	flagsummary(splitavgfilename)
-	clearcal(vis = splitavgfilename)
-	myfile2 = [splitavgfilename]
-	if usetclean == True:
-		myselfcal(myfile2,ref_ant,scaloops,pcaloops,mJythreshold,imcellsize,imsize_pix,use_nterms,nwprojpl,scalsolints,clipresid,'','',False,niter_start)
+        casalog.filter('INFO')
+        logging.info("A flagging summary is provided for the MS file.")
+        flagsummary(splitavgfilename)
+        clearcal(vis = splitavgfilename)
+        myfile2 = [splitavgfilename]
+        if usetclean == True:
+                myselfcal(myfile2,ref_ant,scaloops,pcaloops,mJythreshold,imcellsize,imsize_pix,use_nterms,nwprojpl,scalsolints,clipresid,'','',False,niter_start)
 
 

--- a/ugfunctions.py
+++ b/ugfunctions.py
@@ -1,21 +1,18 @@
 
-
-
-
 # FUNCTIONS
 ###############################################################
 # A library of function that are used in the pipeline
 
 def vislistobs(msfile):
-	'''Writes the verbose output of the task listobs.'''
-	ms.open(msfile)  
-	outr=ms.summary(verbose=True,listfile=msfile+'.list')
-#	print("A file containing listobs output is saved.")
-	try:
-		assert os.path.isfile(msfile+'.list'),logging.info("A file containing listobs output is saved.")
-	except AssertionError:
-		logging.info("The listobs output as not saved in a .list file. Please check the CASA log.")
-	return outr
+        '''Writes the verbose output of the task listobs.'''
+        ms.open(msfile)  
+        outr=ms.summary(verbose=True,listfile=msfile+'.list')
+#       print("A file containing listobs output is saved.")
+        try:
+                assert os.path.isfile(msfile+'.list'),logging.info("A file containing listobs output is saved.")
+        except AssertionError:
+                logging.info("The listobs output as not saved in a .list file. Please check the CASA log.")
+        return outr
 
 def getpols(msfile):
         '''Get the number of polarizations in the file'''
@@ -32,184 +29,184 @@ def mypols(inpvis,mypolid):
     return corrtypes
 
 def getfields(msfile):
-	'''get list of field names in the ms'''
-	msmd.open(msfile)  
-	fieldnames = msmd.fieldnames()
-	msmd.done()
-	return fieldnames
+        '''get list of field names in the ms'''
+        msmd.open(msfile)  
+        fieldnames = msmd.fieldnames()
+        msmd.done()
+        return fieldnames
 
 def getscans(msfile, mysrc):
-	'''get a list of scan numbers for the specified source'''
-	msmd.open(msfile)
-	myscan_numbers = msmd.scansforfield(mysrc)
-	myscanlist = myscan_numbers.tolist()
-	msmd.done()
-	return myscanlist
+        '''get a list of scan numbers for the specified source'''
+        msmd.open(msfile)
+        myscan_numbers = msmd.scansforfield(mysrc)
+        myscanlist = myscan_numbers.tolist()
+        msmd.done()
+        return myscanlist
 
 def getantlist(myvis,scanno):
-	msmd.open(myvis)
-	antenna_name = msmd.antennasforscan(scanno)
-	antlist=[]
-	for i in range(0,len(antenna_name)):
-		antlist.append(msmd.antennanames(antenna_name[i])[0])
-	return antlist
+        msmd.open(myvis)
+        antenna_name = msmd.antennasforscan(scanno)
+        antlist=[]
+        for i in range(0,len(antenna_name)):
+                antlist.append(msmd.antennanames(antenna_name[i])[0])
+        return antlist
 
 
 def getnchan(msfile):
-	msmd.open(msfile)
-	nchan = msmd.nchan(0)
-	msmd.done()
-	return nchan
+        msmd.open(msfile)
+        nchan = msmd.nchan(0)
+        msmd.done()
+        return nchan
 
 
-def freq_info(ms_file):									
-	sw = 0
-	msmd.open(ms_file)
-	freq=msmd.chanfreqs(sw)								
-	msmd.done()
-	return freq									
+def freq_info(ms_file):                                                                 
+        sw = 0
+        msmd.open(ms_file)
+        freq=msmd.chanfreqs(sw)                                                         
+        msmd.done()
+        return freq                                                                     
 
 def makebl(ant1,ant2):
-	mybl = ant1+'&'+ant2
-	return mybl
+        mybl = ant1+'&'+ant2
+        return mybl
 
 
 def getbllists(myfile):
-	myfields = getfields(myfile)
-	myallscans =[]
-	for i in range(0,len(myfields)):
-		myallscans.extend(getscans(myfile, myfields[i]))
-	myantlist = getantlist(myfile,int(myallscans[0]))
-	allbl=[]
-	for i in range(0,len(myantlist)):
-		for j in range(0,len(myantlist)):
-			if j>i:
-				allbl.append(makebl(myantlist[i],myantlist[j]))
-	mycc=[]
-	mycaa=[]
-	for i in range(0,len(allbl)):
-		if allbl[i].count('C')==2:
-			mycc.append(allbl[i])
-		else:
-			mycaa.append(allbl[i])
-	myshortbl =[]
-	myshortbl.append(str('; '.join(mycc)))
-	mylongbl =[]
-	mylongbl.append(str('; '.join(mycaa)))
-	return myshortbl, mylongbl
+        myfields = getfields(myfile)
+        myallscans =[]
+        for i in range(0,len(myfields)):
+                myallscans.extend(getscans(myfile, myfields[i]))
+        myantlist = getantlist(myfile,int(myallscans[0]))
+        allbl=[]
+        for i in range(0,len(myantlist)):
+                for j in range(0,len(myantlist)):
+                        if j>i:
+                                allbl.append(makebl(myantlist[i],myantlist[j]))
+        mycc=[]
+        mycaa=[]
+        for i in range(0,len(allbl)):
+                if allbl[i].count('C')==2:
+                        mycc.append(allbl[i])
+                else:
+                        mycaa.append(allbl[i])
+        myshortbl =[]
+        myshortbl.append(str('; '.join(mycc)))
+        mylongbl =[]
+        mylongbl.append(str('; '.join(mycaa)))
+        return myshortbl, mylongbl
 
 
 def getbandcut(inpmsfile):
-	cutoffs = {'L':0.2, 'P':0.3, '235':0.5, '610':0.2, 'b4':0.2, 'b2':0.7, '150':0.7}
-	frange = freq_info(inpmsfile)
-	fmin = min(frange)
-	fmax = max(frange)
-	if fmin > 1000E06:
-		fband = 'L'
-	elif fmin >500E06 and fmin < 1000E06:
-		fband = 'b4'
-	elif fmin >260E06 and fmin < 560E06:
-		fband = 'P'
-	elif fmin > 210E06 and fmin < 260E06:
-		fband = '235'
-	elif fmin > 80E6 and fmin < 200E6:
-		fband = 'b2'
-	else:
-		"Frequency band does not match any of the GMRT bands."
-	logging.info("The frequency band in the file is ")
-	logging.info(fband)
-	xcut = cutoffs.get(fband)
-	logging.info("The mean cutoff used for flagging bad antennas is ")
-	logging.info(xcut)
-	return xcut
+        cutoffs = {'L':0.2, 'P':0.3, '235':0.5, '610':0.2, 'b4':0.2, 'b2':0.7, '150':0.7}
+        frange = freq_info(inpmsfile)
+        fmin = min(frange)
+        fmax = max(frange)
+        if fmin > 1000E06:
+                fband = 'L'
+        elif fmin >500E06 and fmin < 1000E06:
+                fband = 'b4'
+        elif fmin >260E06 and fmin < 560E06:
+                fband = 'P'
+        elif fmin > 210E06 and fmin < 260E06:
+                fband = '235'
+        elif fmin > 80E6 and fmin < 200E6:
+                fband = 'b2'
+        else:
+                "Frequency band does not match any of the GMRT bands."
+        logging.info("The frequency band in the file is ")
+        logging.info(fband)
+        xcut = cutoffs.get(fband)
+        logging.info("The mean cutoff used for flagging bad antennas is ")
+        logging.info(xcut)
+        return xcut
 
 def myvisstatampraw1(myfile,myfield,myspw,myant,mycorr,myscan):
-	default(visstat)
-	mystat = visstat(vis=myfile,axis="amp",datacolumn="data",useflags=False,spw=myspw,
-		field=myfield,selectdata=True,antenna=myant,uvrange="",timerange="",
-		correlation=mycorr,scan=myscan,array="",observation="",timeaverage=False,
-		timebin="0s",timespan="",maxuvwdistance=0.0,disableparallel=None,ddistart=None,
-		taql=None,monolithic_processing=None,intent="",reportingaxes="ddid")
-	mymean1 = mystat['DATA_DESC_ID=0']['mean']
-	return mymean1
+        default(visstat)
+        mystat = visstat(vis=myfile,axis="amp",datacolumn="data",useflags=False,spw=myspw,
+                field=myfield,selectdata=True,antenna=myant,uvrange="",timerange="",
+                correlation=mycorr,scan=myscan,array="",observation="",timeaverage=False,
+                timebin="0s",timespan="",maxuvwdistance=0.0,disableparallel=None,ddistart=None,
+                taql=None,monolithic_processing=None,intent="",reportingaxes="ddid")
+        mymean1 = mystat['DATA_DESC_ID=0']['mean']
+        return mymean1
 
 def myvisstatampraw(myfile,myspw,myant,mycorr,myscan):
-	default(visstat)
-	mystat = visstat(vis=myfile,axis="amp",datacolumn="data",useflags=False,spw=myspw,
-		selectdata=True,antenna=myant,uvrange="",timerange="",
-		correlation=mycorr,scan=myscan,array="",observation="",timeaverage=False,
-		timebin="0s",timespan="",maxuvwdistance=0.0,disableparallel=None,ddistart=None,
-		taql=None,monolithic_processing=None,intent="",reportingaxes="ddid")
-	mymean1 = mystat['DATA_DESC_ID=0']['mean']
-	return mymean1
+        default(visstat)
+        mystat = visstat(vis=myfile,axis="amp",datacolumn="data",useflags=False,spw=myspw,
+                selectdata=True,antenna=myant,uvrange="",timerange="",
+                correlation=mycorr,scan=myscan,array="",observation="",timeaverage=False,
+                timebin="0s",timespan="",maxuvwdistance=0.0,disableparallel=None,ddistart=None,
+                taql=None,monolithic_processing=None,intent="",reportingaxes="ddid")
+        mymean1 = mystat['DATA_DESC_ID=0']['mean']
+        return mymean1
 
 
 def mygaincal_ap1(myfile,mycal,myref,myflagspw,myuvracal,calsuffix):
-	default(gaincal)
-	gaincal(vis=myfile, caltable=str(myfile)+'.AP.G', spw =myflagspw,uvrange=myuvracal,append=True,
-		field=mycal,solint = '120s',refant = myref, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap',
-		gaintable = [str(myfile)+'.K1', str(myfile)+'.B1' ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
-		parang = True )
-	return gaintable
+        default(gaincal)
+        gaincal(vis=myfile, caltable=str(myfile)+'.AP.G', spw =myflagspw,uvrange=myuvracal,append=True,
+                field=mycal,solint = '120s',refant = myref, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap',
+                gaintable = [str(myfile)+'.K1', str(myfile)+'.B1' ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
+                parang = True )
+        return gaintable
 
 
 def mygaincal_ap2(myfile,mycal,myref,myflagspw,myuvracal,calsuffix):
-	default(gaincal)
-	gaincal(vis=myfile, caltable=str(myfile)+'.AP.G'+calsuffix, spw =myflagspw,uvrange=myuvracal,append=True,
-		field=mycal,solint = '120s',refant = myref, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap',
-		gaintable = [str(myfile)+'.K1'+calsuffix, str(myfile)+'.B1'+calsuffix ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
-		parang = True )
-	return gaintable
+        default(gaincal)
+        gaincal(vis=myfile, caltable=str(myfile)+'.AP.G'+calsuffix, spw =myflagspw,uvrange=myuvracal,append=True,
+                field=mycal,solint = '120s',refant = myref, minsnr = 2.0, solmode ='L1R', gaintype = 'G', calmode = 'ap',
+                gaintable = [str(myfile)+'.K1'+calsuffix, str(myfile)+'.B1'+calsuffix ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
+                parang = True )
+        return gaintable
 
 def getfluxcal(myfile,mycalref,myscal):
-	myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G', fluxtable=str(myfile)+'.fluxscale', reference=mycalref, transfer=myscal,
+        myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G', fluxtable=str(myfile)+'.fluxscale', reference=mycalref, transfer=myscal,
                     incremental=False)
-	return myscale
+        return myscale
 
 
 def getfluxcal2(myfile,mycalref,myscal,calsuffix):
-	myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G'+calsuffix, fluxtable=str(myfile)+'.fluxscale'+calsuffix, reference=mycalref,
-       	            transfer=myscal, incremental=False)
-	return myscale
+        myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G'+calsuffix, fluxtable=str(myfile)+'.fluxscale'+calsuffix, reference=mycalref,
+                    transfer=myscal, incremental=False)
+        return myscale
 
 
 
 def mygaincal_ap_redo(myfile,mycal,myref,myflagspw,myuvracal):
-	default(gaincal)
-	gaincal(vis=myfile, caltable=str(myfile)+'.AP.G.'+'recal', append=True, spw =myflagspw, uvrange=myuvracal,
-		field=mycal,solint = '120s',refant = myref, minsnr = 2.0,solmode ='L1R', gaintype = 'G', calmode = 'ap',
-		gaintable = [str(myfile)+'.K1'+'recal', str(myfile)+'.B1'+'recal' ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
-		parang = True )
-	return gaintable
+        default(gaincal)
+        gaincal(vis=myfile, caltable=str(myfile)+'.AP.G.'+'recal', append=True, spw =myflagspw, uvrange=myuvracal,
+                field=mycal,solint = '120s',refant = myref, minsnr = 2.0,solmode ='L1R', gaintype = 'G', calmode = 'ap',
+                gaintable = [str(myfile)+'.K1'+'recal', str(myfile)+'.B1'+'recal' ], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
+                parang = True )
+        return gaintable
 
 def getfluxcal_redo(myfile,mycalref,myscal):
-	myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G'+'recal', fluxtable=str(myfile)+'.fluxscale'+'recal', reference=mycalref,
+        myscale = fluxscale(vis=myfile, caltable=str(myfile)+'.AP.G'+'recal', fluxtable=str(myfile)+'.fluxscale'+'recal', reference=mycalref,
                     transfer=myscal, incremental=False)
-	return myscale
+        return myscale
 
 def mytfcrop(myfile,myfield,myants,tcut,fcut,mydatcol,myflagspw):
-	default(flagdata)
-	flagdata(vis=myfile, antenna = myants, field = myfield,	spw = myflagspw, mode='tfcrop', ntime='300s', combinescans=False,
-		datacolumn=mydatcol, timecutoff=tcut, freqcutoff=fcut, timefit='line', freqfit='line', flagdimension='freqtime',
-		usewindowstats='sum', extendflags = False, action='apply', display='none')
-	return
+        default(flagdata)
+        flagdata(vis=myfile, antenna = myants, field = myfield, spw = myflagspw, mode='tfcrop', ntime='300s', combinescans=False,
+                datacolumn=mydatcol, timecutoff=tcut, freqcutoff=fcut, timefit='line', freqfit='line', flagdimension='freqtime',
+                usewindowstats='sum', extendflags = False, action='apply', display='none')
+        return
 
 
 def myrflag(myfile,myfield, myants, mytimdev, myfdev,mydatcol,myflagspw):
-	default(flagdata)
-	flagdata(vis=myfile, field = myfield, spw = myflagspw, antenna = myants, mode='rflag', ntime='scan', combinescans=False,
-		datacolumn=mydatcol, winsize=3, timedevscale=mytimdev, freqdevscale=myfdev, spectralmax=1000000.0, spectralmin=0.0,
-		extendflags=False, channelavg=False, timeavg=False, action='apply', display='none')
-	return
+        default(flagdata)
+        flagdata(vis=myfile, field = myfield, spw = myflagspw, antenna = myants, mode='rflag', ntime='scan', combinescans=False,
+                datacolumn=mydatcol, winsize=3, timedevscale=mytimdev, freqdevscale=myfdev, spectralmax=1000000.0, spectralmin=0.0,
+                extendflags=False, channelavg=False, timeavg=False, action='apply', display='none')
+        return
 
 
 def myrflagavg(myfile,myfield, myants, mytimdev, myfdev,mydatcol,myflagspw):
-	default(flagdata)
-	flagdata(vis=myfile, field = myfield, spw = myflagspw, antenna = myants, mode='rflag', ntime='300s', combinescans=True,
-		datacolumn=mydatcol, winsize=3,	minchanfrac= 0.8, flagneartime = True, basecnt = True, fieldcnt = True,
-		timedevscale=mytimdev, freqdevscale=myfdev, spectralmax=1000000.0, spectralmin=0.0, extendflags=False,
-		channelavg=False, timeavg=False, action='apply', display='none')
-	return
+        default(flagdata)
+        flagdata(vis=myfile, field = myfield, spw = myflagspw, antenna = myants, mode='rflag', ntime='300s', combinescans=True,
+                datacolumn=mydatcol, winsize=3, minchanfrac= 0.8, flagneartime = True, basecnt = True, fieldcnt = True,
+                timedevscale=mytimdev, freqdevscale=myfdev, spectralmax=1000000.0, spectralmin=0.0, extendflags=False,
+                channelavg=False, timeavg=False, action='apply', display='none')
+        return
 
 def getgainspw(msfilename):
         mynchan = getnchan(msfilename)
@@ -317,255 +314,255 @@ def getgainspw(msfilename):
 
 
 def mysplitinit(myfile,myfield,myspw,mywidth):
-	'''function to split corrected data for any field'''
-	default(mstransform)
-	mstransform(vis=myfile, field=myfield, spw=myspw, chanaverage=False, chanbin=mywidth, datacolumn='corrected', outputvis=str(myfield)+'split.ms')
-	myoutvis=str(myfield)+'split.ms'
-	return myoutvis
+        '''function to split corrected data for any field'''
+        default(mstransform)
+        mstransform(vis=myfile, field=myfield, spw=myspw, chanaverage=False, chanbin=mywidth, datacolumn='corrected', outputvis=str(myfield)+'split.ms')
+        myoutvis=str(myfield)+'split.ms'
+        return myoutvis
 
 
 def mysplitavg(myfile,myfield,myspw,mywidth):
-	'''function to split corrected data for any field'''
-#	myoutname=myfile.split('s')[0]+'avg-split.ms'
-	myoutname='avg-'+myfile
+        '''function to split corrected data for any field'''
+#       myoutname=myfile.split('s')[0]+'avg-split.ms'
+        myoutname='avg-'+myfile
         default(mstransform)
-	mstransform(vis=myfile, field=myfield, spw=myspw, chanaverage=True, chanbin=mywidth, datacolumn='data', outputvis=myoutname)
-	return myoutname
+        mstransform(vis=myfile, field=myfield, spw=myspw, chanaverage=True, chanbin=mywidth, datacolumn='data', outputvis=myoutname)
+        return myoutname
 
 
 def mytclean(myfile,myniter,mythresh,srno,cell,imsize, mynterms1,mywproj):    # you may change the multi-scale inputs as per your field
-	nameprefix = getfields(myfile)[0]#myfile.split('.')[0]
-	print("The image files have the following prefix =",nameprefix)
-	if myniter==0:
-		myoutimg = nameprefix+'-dirty-img'
-	else:
-		myoutimg = nameprefix+'-selfcal'+'img'+str(srno)
-	default(tclean)
-	if mynterms1 > 1:
-		tclean(vis=myfile,
-       			imagename=myoutimg, selectdata= True, field='0', spw='0', imsize=imsize, cell=cell, robust=0, weighting='briggs', 
-       			specmode='mfs',	nterms=mynterms1, niter=myniter, usemask='auto-multithresh',minbeamfrac=0.1, sidelobethreshold = 1.5,
-#			minpsffraction=0.05,
-#			maxpsffraction=0.8,
-			smallscalebias=0.6, threshold= mythresh, aterm =True, pblimit=-1,
-	        	deconvolver='mtmfs', gridder='wproject', wprojplanes=mywproj, scales=[0,5,15],wbawp=False,
-			restoration = True, savemodel='modelcolumn', cyclefactor = 0.5, parallel=False,
-       			interactive=False)
-	else:
-		tclean(vis=myfile,
-       			imagename=myoutimg, selectdata= True, field='0', spw='0', imsize=imsize, cell=cell, robust=0, weighting='briggs', 
-       			specmode='mfs',	nterms=mynterms1, niter=myniter, usemask='auto-multithresh',minbeamfrac=0.1,sidelobethreshold = 1.5,
-#			minpsffraction=0.05,
-#			maxpsffraction=0.8,
-			smallscalebias=0.6, threshold= mythresh, aterm =True, pblimit=-1,
-	        	deconvolver='multiscale', gridder='wproject', wprojplanes=mywproj, scales=[0,5,15],wbawp=False,
-			restoration = True, savemodel='modelcolumn', cyclefactor = 0.5, parallel=False,
-       			interactive=False)
-	return myoutimg
+        nameprefix = getfields(myfile)[0]#myfile.split('.')[0]
+        print("The image files have the following prefix =",nameprefix)
+        if myniter==0:
+                myoutimg = nameprefix+'-dirty-img'
+        else:
+                myoutimg = nameprefix+'-selfcal'+'img'+str(srno)
+        default(tclean)
+        if mynterms1 > 1:
+                tclean(vis=myfile,
+                        imagename=myoutimg, selectdata= True, field='0', spw='0', imsize=imsize, cell=cell, robust=0, weighting='briggs', 
+                        specmode='mfs', nterms=mynterms1, niter=myniter, usemask='auto-multithresh',minbeamfrac=0.1, sidelobethreshold = 1.5,
+#                       minpsffraction=0.05,
+#                       maxpsffraction=0.8,
+                        smallscalebias=0.6, threshold= mythresh, aterm =True, pblimit=-1,
+                        deconvolver='mtmfs', gridder='wproject', wprojplanes=mywproj, scales=[0,5,15],wbawp=False,
+                        restoration = True, savemodel='modelcolumn', cyclefactor = 0.5, parallel=False,
+                        interactive=False)
+        else:
+                tclean(vis=myfile,
+                        imagename=myoutimg, selectdata= True, field='0', spw='0', imsize=imsize, cell=cell, robust=0, weighting='briggs', 
+                        specmode='mfs', nterms=mynterms1, niter=myniter, usemask='auto-multithresh',minbeamfrac=0.1,sidelobethreshold = 1.5,
+#                       minpsffraction=0.05,
+#                       maxpsffraction=0.8,
+                        smallscalebias=0.6, threshold= mythresh, aterm =True, pblimit=-1,
+                        deconvolver='multiscale', gridder='wproject', wprojplanes=mywproj, scales=[0,5,15],wbawp=False,
+                        restoration = True, savemodel='modelcolumn', cyclefactor = 0.5, parallel=False,
+                        interactive=False)
+        return myoutimg
 
 def myonlyclean(myfile,myniter,mythresh,srno,cell,imsize,mynterms1,mywproj):
-	default(clean)
-	clean(vis=myfile,
-	selectdata=True,
-	spw='0',
-	imagename='selfcal'+'img'+str(srno),
-	imsize=imsize,
-	cell=cell,
-	mode='mfs',
-	reffreq='',
-	weighting='briggs',
-	niter=myniter,
-	threshold=mythresh,
-	nterms=mynterms1,
-	gridmode='widefield',
-	wprojplanes=mywproj,
-	interactive=False,
-	usescratch=True)
-	myname = 'selfcal'+'img'+str(srno)
-	return myname
+        default(clean)
+        clean(vis=myfile,
+        selectdata=True,
+        spw='0',
+        imagename='selfcal'+'img'+str(srno),
+        imsize=imsize,
+        cell=cell,
+        mode='mfs',
+        reffreq='',
+        weighting='briggs',
+        niter=myniter,
+        threshold=mythresh,
+        nterms=mynterms1,
+        gridmode='widefield',
+        wprojplanes=mywproj,
+        interactive=False,
+        usescratch=True)
+        myname = 'selfcal'+'img'+str(srno)
+        return myname
 
 
 def mysplit(myfile,srno):
-	filname_pre = getfields(myfile)[0]
-	default(mstransform)
-	mstransform(vis=myfile, field='0', spw='0', datacolumn='corrected', outputvis=filname_pre+'-selfcal'+str(srno)+'.ms')
-	myoutvis=filname_pre+'-selfcal'+str(srno)+'.ms'
-	return myoutvis
+        filname_pre = getfields(myfile)[0]
+        default(mstransform)
+        mstransform(vis=myfile, field='0', spw='0', datacolumn='corrected', outputvis=filname_pre+'-selfcal'+str(srno)+'.ms')
+        myoutvis=filname_pre+'-selfcal'+str(srno)+'.ms'
+        return myoutvis
 
 
 def mygaincal_ap(myfile,myref,mygtable,srno,pap,mysolint,myuvrascal,mygainspw):
-	fprefix = getfields(myfile)[0]
-	if pap=='ap':
-		mycalmode='ap'
-		mysol= mysolint[srno] 
-		mysolnorm = True
-	else:
-		mycalmode='p'
-		mysol= mysolint[srno] 
-		mysolnorm = False
-	if os.path.isdir(fprefix+str(pap)+str(srno)+'.GT'):
-		os.system('rm -rf '+fprefix+str(pap)+str(srno)+'.GT')
-	default(gaincal)
-	gaincal(vis=myfile, caltable=fprefix+str(pap)+str(srno)+'.GT', append=False, field='0', spw=mygainspw,
-		uvrange=myuvrascal, solint = mysol, refant = myref, minsnr = 2.0,solmode='L1R', gaintype = 'G',
-		solnorm= mysolnorm, calmode = mycalmode, gaintable = [], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
-		parang = True )
-	mycal = fprefix+str(pap)+str(srno)+'.GT'
-	return mycal
+        fprefix = getfields(myfile)[0]
+        if pap=='ap':
+                mycalmode='ap'
+                mysol= mysolint[srno] 
+                mysolnorm = True
+        else:
+                mycalmode='p'
+                mysol= mysolint[srno] 
+                mysolnorm = False
+        if os.path.isdir(fprefix+str(pap)+str(srno)+'.GT'):
+                os.system('rm -rf '+fprefix+str(pap)+str(srno)+'.GT')
+        default(gaincal)
+        gaincal(vis=myfile, caltable=fprefix+str(pap)+str(srno)+'.GT', append=False, field='0', spw=mygainspw,
+                uvrange=myuvrascal, solint = mysol, refant = myref, minsnr = 2.0,solmode='L1R', gaintype = 'G',
+                solnorm= mysolnorm, calmode = mycalmode, gaintable = [], interp = ['nearest,nearestflag', 'nearest,nearestflag' ], 
+                parang = True )
+        mycal = fprefix+str(pap)+str(srno)+'.GT'
+        return mycal
 
 
 def myapplycal(myfile,mygaintables):
-	default(applycal)
-	applycal(vis=myfile, field='0', gaintable=mygaintables, gainfield=['0'], applymode='calflag', 
-	         interp=['linear'], calwt=False, parang=False)
-	print('Ran applycal.')
+        default(applycal)
+        applycal(vis=myfile, field='0', gaintable=mygaintables, gainfield=['0'], applymode='calflag', 
+                 interp=['linear'], calwt=False, parang=False)
+        print('Ran applycal.')
 
 
 
 
 def flagresidual(myfile,myclipresid,myflagspw):
-	default(flagdata)
-	flagdata(vis=myfile, mode ='rflag', datacolumn="RESIDUAL_DATA", field='', timecutoff=6.0,  freqcutoff=6.0,
-		timefit="line", freqfit="line",	flagdimension="freqtime", extendflags=False, timedevscale=6.0,
-		freqdevscale=6.0, spectralmax=500.0, extendpols=False, growaround=False, flagneartime=False,
-		flagnearfreq=False, action="apply", flagbackup=True, overwrite=True, writeflags=True)
-	default(flagdata)
-	flagdata(vis=myfile, mode ='clip', datacolumn="RESIDUAL_DATA", clipminmax=myclipresid,
-		clipoutside=True, clipzeros=True, field='', spw=myflagspw, extendflags=False,
-		extendpols=False, growaround=False, flagneartime=False,	flagnearfreq=False,
-		action="apply",	flagbackup=True, overwrite=True, writeflags=True)
-	flagdata(vis=myfile,mode="summary",datacolumn="RESIDUAL_DATA", extendflags=False, 
-		name=myfile+'temp.summary', action="apply", flagbackup=True,overwrite=True, writeflags=True)
+        default(flagdata)
+        flagdata(vis=myfile, mode ='rflag', datacolumn="RESIDUAL_DATA", field='', timecutoff=6.0,  freqcutoff=6.0,
+                timefit="line", freqfit="line", flagdimension="freqtime", extendflags=False, timedevscale=6.0,
+                freqdevscale=6.0, spectralmax=500.0, extendpols=False, growaround=False, flagneartime=False,
+                flagnearfreq=False, action="apply", flagbackup=True, overwrite=True, writeflags=True)
+        default(flagdata)
+        flagdata(vis=myfile, mode ='clip', datacolumn="RESIDUAL_DATA", clipminmax=myclipresid,
+                clipoutside=True, clipzeros=True, field='', spw=myflagspw, extendflags=False,
+                extendpols=False, growaround=False, flagneartime=False, flagnearfreq=False,
+                action="apply", flagbackup=True, overwrite=True, writeflags=True)
+        flagdata(vis=myfile,mode="summary",datacolumn="RESIDUAL_DATA", extendflags=False, 
+                name=myfile+'temp.summary', action="apply", flagbackup=True,overwrite=True, writeflags=True)
 #
 
 
-	 
+         
 
 def myselfcal(myfile,myref,nloops,nploops,myvalinit,mycellsize,myimagesize,mynterms2,mywproj1,mysolint1,myclipresid,myflagspw,mygainspw2,mymakedirty,niterstart):
-	myref = myref
-	nscal = nloops # number of selfcal loops
-	npal = nploops # number of phasecal loops
-	# selfcal loop
-	myimages=[]
-	mygt=[]
-	myniterstart = niterstart
-	myniterend = 200000	
-	if nscal == 0:
-		i = nscal
-		myniter = 0 # this is to make a dirty image
-		mythresh = str(myvalinit/(i+1))+'mJy'
-		print("Using "+ myfile[i]+" for making only an image.")
-		if usetclean == False:
-			myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
-		else:
-			myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
+        myref = myref
+        nscal = nloops # number of selfcal loops
+        npal = nploops # number of phasecal loops
+        # selfcal loop
+        myimages=[]
+        mygt=[]
+        myniterstart = niterstart
+        myniterend = 200000     
+        if nscal == 0:
+                i = nscal
+                myniter = 0 # this is to make a dirty image
+                mythresh = str(myvalinit/(i+1))+'mJy'
+                print("Using "+ myfile[i]+" for making only an image.")
+                if usetclean == False:
+                        myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
+                else:
+                        myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
                 if mynterms2 > 1:
                         exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
                 else:
                         exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
 
-	else:
-		for i in range(0,nscal+1): # plan 4 P and 4AP iterations
-			if mymakedirty == True:
-				if i == 0:
-					myniter = 0 # this is to make a dirty image
-					mythresh = str(myvalinit/(i+1))+'mJy'
-					print("Using "+ myfile[i]+" for making only a dirty image.")
-					if usetclean == False:
-						myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
-					else:
-						myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
-					if mynterms2 > 1:
-						exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
-					else:
-						exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
+        else:
+                for i in range(0,nscal+1): # plan 4 P and 4AP iterations
+                        if mymakedirty == True:
+                                if i == 0:
+                                        myniter = 0 # this is to make a dirty image
+                                        mythresh = str(myvalinit/(i+1))+'mJy'
+                                        print("Using "+ myfile[i]+" for making only a dirty image.")
+                                        if usetclean == False:
+                                                myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
+                                        else:
+                                                myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
+                                        if mynterms2 > 1:
+                                                exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
+                                        else:
+                                                exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
 
-			else:
-				myniter=int(myniterstart*2**i) #myniterstart*(2**i)  # niter is doubled with every iteration int(startniter*2**count)
-				if myniter > myniterend:
-					myniter = myniterend
-				mythresh = str(myvalinit/(i+1))+'mJy'
-				if i < npal:
-					mypap = 'p'
-#					print("Using "+ myfile[i]+" for imaging.")
-					try:
-						assert os.path.isdir(myfile[i])
-					except AssertionError:
-						logging.info("The MS file not found for imaging.")
-						sys.exit()
-					logging.info("Using "+ myfile[i]+" for imaging.")
-					if usetclean == False:
-						myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
-					else:
-						myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
-					if mynterms2 > 1:
-						exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
-					else:
-						exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
-					myimages.append(myimg)	# list of all the images created so far
-					flagresidual(myfile[i],clipresid,'')
-					if i>0:
-						myctables = mygaincal_ap(myfile[i],myref,mygt[i-1],i,mypap,mysolint1,uvrascal,mygainspw2)
-					else:					
-						myctables = mygaincal_ap(myfile[i],myref,mygt,i,mypap,mysolint1,uvrascal,mygainspw2)						
-					mygt.append(myctables) # full list of gaintables
-					if i < nscal+1:
-						myapplycal(myfile[i],mygt[i])
-						myoutfile= mysplit(myfile[i],i)
-						myfile.append(myoutfile)
-				else:
-					mypap = 'ap'
-#					print("Using "+ myfile[i]+" for imaging.")
+                        else:
+                                myniter=int(myniterstart*2**i) #myniterstart*(2**i)  # niter is doubled with every iteration int(startniter*2**count)
+                                if myniter > myniterend:
+                                        myniter = myniterend
+                                mythresh = str(myvalinit/(i+1))+'mJy'
+                                if i < npal:
+                                        mypap = 'p'
+#                                       print("Using "+ myfile[i]+" for imaging.")
                                         try:
                                                 assert os.path.isdir(myfile[i])
                                         except AssertionError:
                                                 logging.info("The MS file not found for imaging.")
                                                 sys.exit()
-					if usetclean == False:
-						myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
-					else:
-						myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
-					if mynterms2 > 1:
-						exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
-					else:
-						exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
-					myimages.append(myimg)	# list of all the images created so far
-					flagresidual(myfile[i],clipresid,'')
-					if i!= nscal:
-						myctables = mygaincal_ap(myfile[i],myref,mygt[i-1],i,mypap,mysolint1,'',mygainspw2)
-						mygt.append(myctables) # full list of gaintables
-						if i < nscal+1:
-							myapplycal(myfile[i],mygt[i])
-							myoutfile= mysplit(myfile[i],i)
-							myfile.append(myoutfile)
-#				print("Visibilities from the previous selfcal will be deleted.")
-				logging.info("Visibilities from the previous selfcal will be deleted.")
-				if i < nscal:
-					fprefix = getfields(myfile[i])[0]
-					myoldvis = fprefix+'-selfcal'+str(i-1)+'.ms'
-#					print("Deleting "+str(myoldvis))
-					logging.info("Deleting "+str(myoldvis))
-					os.system('rm -rf '+str(myoldvis))
-#			print('Ran the selfcal loop')
-	return myfile, mygt, myimages
+                                        logging.info("Using "+ myfile[i]+" for imaging.")
+                                        if usetclean == False:
+                                                myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
+                                        else:
+                                                myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
+                                        if mynterms2 > 1:
+                                                exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
+                                        else:
+                                                exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
+                                        myimages.append(myimg)  # list of all the images created so far
+                                        flagresidual(myfile[i],clipresid,'')
+                                        if i>0:
+                                                myctables = mygaincal_ap(myfile[i],myref,mygt[i-1],i,mypap,mysolint1,uvrascal,mygainspw2)
+                                        else:                                   
+                                                myctables = mygaincal_ap(myfile[i],myref,mygt,i,mypap,mysolint1,uvrascal,mygainspw2)                                            
+                                        mygt.append(myctables) # full list of gaintables
+                                        if i < nscal+1:
+                                                myapplycal(myfile[i],mygt[i])
+                                                myoutfile= mysplit(myfile[i],i)
+                                                myfile.append(myoutfile)
+                                else:
+                                        mypap = 'ap'
+#                                       print("Using "+ myfile[i]+" for imaging.")
+                                        try:
+                                                assert os.path.isdir(myfile[i])
+                                        except AssertionError:
+                                                logging.info("The MS file not found for imaging.")
+                                                sys.exit()
+                                        if usetclean == False:
+                                                myimg = myonlyclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # clean
+                                        else:
+                                                myimg = mytclean(myfile[i],myniter,mythresh,i,mycellsize,myimagesize,mynterms2,mywproj1)   # tclean
+                                        if mynterms2 > 1:
+                                                exportfits(imagename=myimg+'.image.tt0', fitsimage=myimg+'.fits')
+                                        else:
+                                                exportfits(imagename=myimg+'.image', fitsimage=myimg+'.fits')
+                                        myimages.append(myimg)  # list of all the images created so far
+                                        flagresidual(myfile[i],clipresid,'')
+                                        if i!= nscal:
+                                                myctables = mygaincal_ap(myfile[i],myref,mygt[i-1],i,mypap,mysolint1,'',mygainspw2)
+                                                mygt.append(myctables) # full list of gaintables
+                                                if i < nscal+1:
+                                                        myapplycal(myfile[i],mygt[i])
+                                                        myoutfile= mysplit(myfile[i],i)
+                                                        myfile.append(myoutfile)
+#                               print("Visibilities from the previous selfcal will be deleted.")
+                                logging.info("Visibilities from the previous selfcal will be deleted.")
+                                if i < nscal:
+                                        fprefix = getfields(myfile[i])[0]
+                                        myoldvis = fprefix+'-selfcal'+str(i-1)+'.ms'
+#                                       print("Deleting "+str(myoldvis))
+                                        logging.info("Deleting "+str(myoldvis))
+                                        os.system('rm -rf '+str(myoldvis))
+#                       print('Ran the selfcal loop')
+        return myfile, mygt, myimages
 
 
 
 def flagsummary(myfile):
-	try:
-		assert os.path.isdir(myfile), "The MS file was not found."
-	except AssertionError:
-		logging.info("The MS file was not found.")
-		sys.exit()
+        try:
+                assert os.path.isdir(myfile), "The MS file was not found."
+        except AssertionError:
+                logging.info("The MS file was not found.")
+                sys.exit()
         s = flagdata(vis=myfile, mode='summary')
         allkeys = s.keys()
-	logging.info("Flagging percentage:")
+        logging.info("Flagging percentage:")
         for x in allkeys:
                 try:
                         for y in s[x].keys():
                                 flagged_percent = 100.*(s[x][y]['flagged']/s[x][y]['total'])
 #                                logging.info(x, y, "%0.2f" % flagged_percent, "% flagged.")
-				logstring = str(x)+' '+str(y)+' '+str(flagged_percent)
+                                logstring = str(x)+' '+str(y)+' '+str(flagged_percent)
                                 logging.info(logstring)
                 except AttributeError:
                         pass


### PR DESCRIPTION
Hi,
I was unable to firstly run the Pipeline in a standard environment calling to it directly with `casa -c {path}/capture.py` due to the following issues:
1. Indentation errors returned due to a mix between tab and spaces in several lines along the two `.py` files.
2. Modules like `numpy` (as `np`) were used but not imported in `capture.py`.
3. `ugfunctions.py` and `vla-cals.list` were not found as the content of the `uGMRT-pipeline` was not located inside my current working directory.
4. CASA version >6 uses Python 3, which does not allow `ConfigParser` (renamed to `configparser`) and the `execfile`.

This pull request fixes 1 and 2.
Then, it solves 3 by obtaining the directory at which `capture.py` is located. In this sense, one can keep the full code in a single directory, and call it from any working directory as long as the `config_capture.ini` files is found there.
For 4, I modified the code around these two commands to make them compatible for both Python 2 and 3. In this sense, the pipeline is still compatible with both current CASA versions.

No changes are related to the actual work of the pipeline.